### PR TITLE
Add Arduino IDE required fields to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,9 +3,11 @@
 name=dali_master
 version=1.6.0
 author=Steve Parker
+maintainer=Steve Parker
 license=Apache License Version 2.0
 sentence=DALI Master Particle library for use with LED-Warrior-14
-# paragraph=a longer description of this library, always prepended with sentence when shown
+paragraph=
+category=Signal Input/Output
 url=https://github.com/SorX14/dali_master
 repository=https://github.com/SorX14/dali_master.git
 # architectures=a list of supported boards if this library is hardware dependent, like particle-photon,particle-electron


### PR DESCRIPTION
When a required field is missing from library.properties the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format